### PR TITLE
Improve the display of jobs on user page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -115,7 +115,8 @@ class UsersController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_user
-      @user = User.find(params[:id])
+      user = User.find(params[:id])
+      @user = UserPresenter.new(user, view_context)
     end
 
     # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/models/loss.rb
+++ b/app/models/loss.rb
@@ -11,6 +11,8 @@ class Loss < ActiveRecord::Base
   belongs_to :job
   has_one :customer, through: :job
 
+  delegate :name, to: :loss_type, allow_nil: true, prefix: true
+
   include PublicActivity::Model
   tracked owner: Proc.new{ |controller, model| controller.current_user }
 

--- a/app/presenters/base_presenter.rb
+++ b/app/presenters/base_presenter.rb
@@ -1,0 +1,11 @@
+class BasePresenter < SimpleDelegator
+  def initialize(model, view)
+    @view = view
+    @model = model
+    super(model)
+  end
+
+  def h
+    @view
+  end
+end

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -1,0 +1,15 @@
+class UserPresenter < BasePresenter
+  def jobs_owned_by_user
+    jobs.owned_by(@model)
+  end
+
+  def jobs_entered_by_user
+    jobs.entered_by(@model)
+  end
+
+  private
+
+  def jobs
+    Job.latest_first.limit(20)
+  end
+end

--- a/app/views/users/_job.html.erb
+++ b/app/views/users/_job.html.erb
@@ -1,0 +1,10 @@
+<tr>
+  <td><%= link_to job.id, job %></td>
+  <td><%= job.job_status_name %></td>
+  <td><%= job.name %></td>
+  <td><%= job.customer_full_name %></td>
+  <td><%= job.franchise_name %></td>
+  <td><%= job.loss_type_names.join('<br/>').html_safe %></td>
+  <td><%= job.last_action %></td>
+  <td><%= job.job_coordinator_full_name %></td>
+</tr>

--- a/app/views/users/_jobs.html.erb
+++ b/app/views/users/_jobs.html.erb
@@ -1,0 +1,15 @@
+<% if jobs.any? %>
+  <table class="table table-striped table-condensed table-striped">
+    <tr>
+      <th>Id</th>
+      <th>Status</th>
+      <th>Name</th>
+      <th>Customer</th>
+      <th>Franchise</th>
+      <th>Loss Type</th>
+      <th>Last Updated</th>
+      <th>Coordinator</th>
+    </tr>
+    <%= render partial: 'job', collection: jobs, as: :job %>
+  </table>
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -58,25 +58,20 @@
       <div class="panel-heading">
         <ul class="nav nav-tabs">
           <li class="active">
-            <a href="#notes" aria-controls="entered" role="tab" data-toggle="tab">Recent Jobs Entered</a>
+            <a href="#entered" aria-controls="entered" role="tab" data-toggle="tab">Recent Jobs Entered</a>
           </li>
           <li>
-            <a href="#upload" aria-controls="assigned" role="tab" data-toggle="tab">Recent Jobs Assigned</a>
+            <a href="#assigned" aria-controls="assigned" role="tab" data-toggle="tab">Recent Jobs Assigned</a>
           </li>
-
         </ul>
       </div>
       <div class="panel-body">
         <div class="tab-content">
           <div class="tab-pane fade in active" id="entered">
-            <% Job.where(entered_by_id: @user.id).last(20).each do |job| %>
-              <%= link_to job.id, job_path(job.id) %> <%= job.try(:name) %><br />
-            <% end %>
+            <%= render partial: 'jobs', locals: {jobs: @user.jobs_entered_by_user} %>
           </div>
           <div class="tab-pane fade" id="assigned">
-            <% Job.where(coordinator_id: @user.id).last(20).each do |job| %>
-              <%= link_to job.id, job_path(job.id) %> <%= job.try(:name) %><br />
-            <% end %>
+            <%= render partial: 'jobs', locals: {jobs: @user.jobs_owned_by_user} %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR is to change the simple list of links to jobs on `users#show` to something a little bit more useful.

@bradbergeron-us currently I'm just displaying the status as a field in the table rather than separating out into separate tables. I think for Entered By it makes sense this way, but for the Coordinator list I probably should separate by status, what do you think?