### PR TITLE
Fix the loss type filter on jobs#index

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -25,7 +25,7 @@ class JobsController < ApplicationController
   # GET /jobs
   # GET /jobs.json
   def index
-    @search = Job.where.not(status_id: nil).order('fnol_received DESC').search(params[:q])
+    @search = Job.where.not(status_id: nil).search(params[:q])
     @jobs = JobsPresenter.new(@search.result, view_context, params[:page])
 
     respond_to do |format|

--- a/test/controllers/jobs_controller_test.rb
+++ b/test/controllers/jobs_controller_test.rb
@@ -14,6 +14,12 @@ class JobsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test '#index filters on loss_type' do
+    loss_type = loss_types(:fire)
+    get :index, q: {losses_loss_type_id_in: [loss_type.id]}
+    assert_response :success
+  end
+
   test '#new' do
     get :new
     assert_response :success

--- a/test/fixtures/loss_types.yml
+++ b/test/fixtures/loss_types.yml
@@ -1,7 +1,7 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  name: MyString
+fire:
+  name: Fire
 
-two:
-  name: MyString
+water:
+  name: Water


### PR DESCRIPTION
It was erroring due to the `fnol_received` order by being passed to the search method. It was being ordered later on so that particular order was not necessary.
