### PR TITLE
Fix phone number issue when sending to shaprspring

### DIFF
--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -138,7 +138,7 @@ class Customer < ActiveRecord::Base
       "method":"createLeads",
       "params":
         {"objects":
-          [{"firstName": self.first_name,"lastName": self.last_name,"emailAddress": self.email, "companyName": self.company_name, "title": self.title, "website": self.website, "street": self.try(:address).try(:address_1), "city": self.try(:address).try(:city), "state": self.try(:address).try(:state).try(:name), "mobilePhoneNumber": self.try(:phones).where(type_id: 1).first.try(:number), "homePhoneNumber": self.try(:phones).where(type_id: 3).first.try(:number), "officePhoneNumber": self.try(:phones).where(type_id: 2).first.try(:number), "faxNumber": self.try(:phones).where(type_id: 4).first.try(:number)}]
+          [{"firstName": self.first_name,"lastName": self.last_name,"emailAddress": self.email, "companyName": self.company_name, "title": self.title, "website": self.website, "street": self.try(:address).try(:address_1), "city": self.try(:address).try(:city), "state": self.try(:address).try(:state).try(:name), "mobilePhoneNumber": self.try(:phones).where(type_id: 1).first.try(:number), "officePhoneNumber": self.try(:phones).where(type_id: 2).first.try(:number), "faxNumber": self.try(:phones).where(type_id: 4).first.try(:number)}]
         },
       "id":"1"
     }.to_json


### PR DESCRIPTION
We were getting the following warning in tests so I decided to investigate: `/app/models/customer.rb:137: warning: key :mobilePhoneNumber is duplicated and overwritten on line 137`

Basically we were setting the key `mobilePhoneNumber` twice - once for phone type 1 (Cell), and also for phone type 3 (Home).

I've simply changed phone type 3 to `homePhoneNumber`, but not sure if this is okay - is there a `homePhoneNumber` field in sharpspring we can send to, or should we just get rid of the home phone number here?