### PR TITLE
Fix links in vendors table

### DIFF
--- a/app/assets/javascripts/bootstrap-table-formatters.js
+++ b/app/assets/javascripts/bootstrap-table-formatters.js
@@ -1,17 +1,29 @@
-function LinkFormatter(value, row, index) {
-  var val = "";
-  if (value) {
-    val = value;
-  } else {
-    val = row.id;
-  }
-  return "<a href='jobs/" + row.id + "'>" + val + "</a>";
+function ContactLinkFormatter(value, row, index) {
+  return "<a href='/contacts/" + row.id + "'>" + value + "</a>";
+}
+function FranchiseLinkFormatter(value, row, index) {
+  return "<a href='/franchises/" + row.id + "'>" + value + "</a>";
+}
+function InsuranceCompanyLinkFormatter(value, row, index) {
+  return "<a href='/insurance_companies/" + row.id + "'>" + value + "</a>";
 }
 function UserLinkFormatter(value, row, index) {
-  return "<a href='users/" + row.id + "'>" + value + "</a>";
+  return "<a href='/users/" + row.id + "'>" + value + "</a>";
 }
 function WorkOrderLinkFormatter(value, row, index) {
-  return "<a href='jobs/" + row.job_id + "/work_orders/" + row.id + "'>" + value + "</a>";
+  return "<a href='/jobs/" + row.job_id + "/work_orders/" + row.id + "'>" + value + "</a>";
+}
+function VendorLinkFormatter(value, row, index) {
+  return "<a href='/vendors/" + row.id + "'>" + value + "</a>";
+}
+function UploadLinkFormatter(value, row, index) {
+  return "<a href='" + value + "'>View/Download</a>";
+}
+function DeleteUpload(value, row, index) {
+  return "<a data-method='delete' data-confirm='Are you sure?' href='/jobs/<%= @job.id %>/uploads/" + row.id + "'>Delete</a>";
+}
+function CallLinkFormatter(value, row, index) {
+  return "<a target='_blank' href='/calls/" + row.id + "'>" + value + "</a>";
 }
 function JobLinkFormatter(value, row, index) {
   var val = "";
@@ -20,12 +32,24 @@ function JobLinkFormatter(value, row, index) {
   } else {
     val = row.id;
   }
-  return "<a href='jobs/" + row.job_id +"'>" + val + "</a>";
+  return "<a href='/jobs/" + row.job_id +"'>" + val + "</a>";
 }
 function WorkOrderAcknowledge(value, row, index) {
   if (row.acknowledgement == true) {
     return "Work Order Acknolwedged"
   } else {
-    return "<a href='jobs/" + row.job_id +"/work_orders/" + row.id + "/acknolwedge'>Acknolwedge Work Order</a>";
+    return "<a href='/jobs/" + row.job_id +"/work_orders/" + row.id + "/acknolwedge'>Acknolwedge Work Order</a>";
   }
+}
+function AddVendor(value, row, index) {
+  return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
+}
+function AddContact(value, row, index) {
+  return "<a class='add-contact' href='id=" + row.id + "&name=" + row.first_name + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
+}
+function CallRailTimeline(value, row, index) {
+  return "<a href='https://app.callrail.com/calls/" + value + "'>Timeline Link</a>";
+}
+function ReturnCallRail(value, row, index){
+  return "<a class='btn btn-primary' href='https://app.callrail.com/a/686639065/leadcenter/#/calls/" + value + "'>Return Call</a>";
 }

--- a/app/views/calls/index.html.erb
+++ b/app/views/calls/index.html.erb
@@ -1,52 +1,39 @@
 <p id="notice"><%= notice %></p>
 
 <div class="row">
-	<div class="col-lg-12">
-		<div class="panel panel-default">
-			<div class="panel-heading">Calls</div>
-			<div class="panel-body">
-				<table
-					data-toggle="table"
-					data-url="calls"
-					data-show-refresh="true"
-					data-show-toggle="true"
-					data-show-columns="true"
-					data-search="true"
-					data-flat="true"
-					data-select-item-name="toolbar1"
-					data-pagination="true"
-					data-sort-name="id"
-					data-sort-order="desc">
-					<thead>
-						<tr>
-							<th data-field="id" data-sortable="true" data-sort-order='desc' data-formatter="LinkFormatter">Call ID</th>
-							<th data-field="callrail_id" data-sortable="true">CallRail ID</th>
-							<th data-field="datetime" data-sortable="true">Call Date</th>
-							<th data-field="customer_phone_number" data-sortable="true">Customer Phone Number</th>
-							<th data-field="customer_name" data-sortable="true">Customer Name</th>
-							<th data-field="utm_campaign" data-sortable="true">UTM Campaign</th>
-							<th data-field="duration" data-sortable="true">Duration</th>
-							<th data-field="job_id" data-sortable="true" data-formatter="JobLinkFormatter">Asssociated Job ID</th>
+  <div class="col-lg-12">
+    <div class="panel panel-default">
+      <div class="panel-heading">Calls</div>
+      <div class="panel-body">
+        <table
+          data-toggle="table"
+          data-url="calls"
+          data-show-refresh="true"
+          data-show-toggle="true"
+          data-show-columns="true"
+          data-search="true"
+          data-flat="true"
+          data-select-item-name="toolbar1"
+          data-pagination="true"
+          data-sort-name="id"
+          data-sort-order="desc">
+          <thead>
+            <tr>
+              <th data-field="id" data-sortable="true" data-sort-order='desc' data-formatter="CallLinkFormatter">Call ID</th>
+              <th data-field="callrail_id" data-sortable="true">CallRail ID</th>
+              <th data-field="datetime" data-sortable="true">Call Date</th>
+              <th data-field="customer_phone_number" data-sortable="true">Customer Phone Number</th>
+              <th data-field="customer_name" data-sortable="true">Customer Name</th>
+              <th data-field="utm_campaign" data-sortable="true">UTM Campaign</th>
+              <th data-field="duration" data-sortable="true">Duration</th>
+              <th data-field="job_id" data-sortable="true" data-formatter="JobLinkFormatter">Asssociated Job ID</th>
 
-						</tr>
-					</thead>
-				</table>
-			</div>
-		</div>
-	</div>
+            </tr>
+          </thead>
+        </table>
+      </div>
+    </div>
+  </div>
 </div>
-
-<script>
-	function LinkFormatter(value, row, index) {
-		return "<a href='calls/" + row.id + "'>" + value + "</a>";
-	}
-  function JobLinkFormatter(value, row, index) {
-    if (value != null){
-      return "<a href='/jobs/" + value + "'>" + value + "</a>";
-    }
-
-	}
-</script>
-
 
 <%= link_to 'New Call', new_call_path %>

--- a/app/views/companies/show.html.erb
+++ b/app/views/companies/show.html.erb
@@ -254,15 +254,6 @@
             e.preventDefault();
             $("#wrapper").toggleClass("toggled");
         });
-        function LinkFormatter(value, row, index) {
-            return "<a target='_blank href='/calls/" + row.id + ">" + value + "</a>";
-        }
-        function AddVendor(value, row, index) {
-            return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
-        }
-        function CallRailTimeline(value, row, index) {
-            return "<a href='https://app.callrail.com/calls/" + value + "'>Timeline Link</a>";
-        }
 
         flatpickr(".datePicker", {
             enableTime: false,

--- a/app/views/contact_assignments/_form.html.erb
+++ b/app/views/contact_assignments/_form.html.erb
@@ -37,39 +37,40 @@
                     <%= f.submit "Create Referral Assignment", class: "btn btn-primary" %>
                 </div>
             </div>
-        </div <% end %>
+          </div>
+      <% end %>
     </div>
 </div>
 </div>
 <div class="col-lg-12">
-<div class="panel panel-default">
-    <div class="panel-heading">Contacts</div>
-    <div class="panel-body table-responsive">
-        <table
-            class="resp"
-            data-toggle="table"
-            data-url="/contacts"
-            data-show-refresh="true"
-            data-show-toggle="true"
-            data-show-columns="true"
-            data-search="true"
-            data-flat="true"
-            data-select-item-name="toolbar1"
-            data-pagination="true"
-            data-sort-name="id"
-            data-sort-order="asc">
-            <thead>
-                <tr>
-                    <th data-field="id" data-sortable="true" data-formatter="AddContact"></th>
-                    <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Contact ID</th>
-                    <th data-field="company" data-sortable="true">Company</th>
-                    <th data-field="first_name" data-sortable="true">First Name</th>
-                    <th data-field="last_name" data-sortable="true">Last Name</th>
-                    <th data-field="email" data-sortable="true">Email</th>
-                    <th data-field="user.first_name" data-sortable="true">Owner</th>
-                </tr>
-            </thead>
-        </table>
-    </div>
-</div>
+  <div class="panel panel-default">
+      <div class="panel-heading">Contacts</div>
+      <div class="panel-body table-responsive">
+          <table
+              class="resp"
+              data-toggle="table"
+              data-url="/contacts"
+              data-show-refresh="true"
+              data-show-toggle="true"
+              data-show-columns="true"
+              data-search="true"
+              data-flat="true"
+              data-select-item-name="toolbar1"
+              data-pagination="true"
+              data-sort-name="id"
+              data-sort-order="asc">
+              <thead>
+                  <tr>
+                      <th data-field="id" data-sortable="true" data-formatter="AddContact"></th>
+                      <th data-field="id" data-sortable="true" data-formatter="ContactLinkFormatter">Contact ID</th>
+                      <th data-field="company" data-sortable="true">Company</th>
+                      <th data-field="first_name" data-sortable="true">First Name</th>
+                      <th data-field="last_name" data-sortable="true">Last Name</th>
+                      <th data-field="email" data-sortable="true">Email</th>
+                      <th data-field="user.first_name" data-sortable="true">Owner</th>
+                  </tr>
+              </thead>
+          </table>
+      </div>
+  </div>
 </div>

--- a/app/views/contact_assignments/new.html.erb
+++ b/app/views/contact_assignments/new.html.erb
@@ -20,13 +20,4 @@
     </div>
 </div>
 
-<script>
-    function LinkFormatter(value, row, index) {
-        return "<a href='/contacts/" + row.id + "'>" + value + "</a>";
-    }
-    function AddContact(value, row, index) {
-        return "<a class='add-contact' href='id=" + row.id + "&name=" + row.first_name + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
-    }
-</script>
-
 <%= link_to 'Back', job_contact_assignments_path(@job) %>

--- a/app/views/contacts/index.html.erb
+++ b/app/views/contacts/index.html.erb
@@ -20,7 +20,7 @@
                         <thead>
                             <tr>
                                 <th data-field="state" data-checkbox="true">Contact ID</th>
-                                <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Contact ID</th>
+                                <th data-field="id" data-sortable="true" data-formatter="ContactLinkFormatter">Contact ID</th>
 
 
                             </tr>
@@ -32,9 +32,3 @@
     </div>
 </div>
 <%= link_to 'New Contact', new_contact_path %>
-
-<script>
-    function LinkFormatter(value, row, index) {
-        return "<a href='contacts/" + row.id + "'>" + value + "</a>";
-    }
-</script>

--- a/app/views/customers/show.html.erb
+++ b/app/views/customers/show.html.erb
@@ -231,7 +231,7 @@
                                                     <thead>
                                                         <tr>
                                                             <th data-field="id" data-sortable="true" data-formatter="AddVendor"></th>
-                                                            <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Call Link</th>
+                                                            <th data-field="id" data-sortable="true" data-formatter="CallLinkFormatter">Call Link</th>
                                                             <th data-field="callrail_id" data-sortable="true">CallRail ID</th>
                                                             <th data-field="datetime" data-sortable="true">Call Date/Time</th>
                                                             <th data-field="customer_phone_number" data-sortable="true">Phone Number</th>
@@ -459,15 +459,6 @@
             e.preventDefault();
             $("#wrapper").toggleClass("toggled");
         });
-        function LinkFormatter(value, row, index) {
-            return "<a target='_blank href='/calls/" + row.id + ">" + value + "</a>";
-        }
-        function AddVendor(value, row, index) {
-            return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
-        }
-        function CallRailTimeline(value, row, index) {
-            return "<a href='https://app.callrail.com/calls/" + value + "'>Timeline Link</a>";
-        }
 
         flatpickr(".datePicker", {
             enableTime: false,

--- a/app/views/franchises/index.html.erb
+++ b/app/views/franchises/index.html.erb
@@ -33,7 +33,7 @@
                         <thead>
                             <tr>
                                 <th data-field="state" data-checkbox="true">Franchise ID</th>
-                                <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Franchise ID</th>
+                                <th data-field="id" data-sortable="true" data-formatter="FranchiseLinkFormatter">Franchise ID</th>
                                 <th data-field="name" data-sortable="true">Name</th>
                                 <th data-field="franchise_number" data-sortable="true">Franchise Number</th>
                                 <th data-field="legal_name" data-sortable="true">Legal Name</th>
@@ -54,10 +54,3 @@
         </div>
     </div>
 </div>
-
-
-<script>
-    function LinkFormatter(value, row, index) {
-        return "<a href='franchises/" + row.id + "'>" + value + "</a>";
-    }
-</script>

--- a/app/views/franchises/show.html.erb
+++ b/app/views/franchises/show.html.erb
@@ -164,7 +164,7 @@
             data-sort-order="desc">
             <thead>
               <tr>
-                <th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job Name</th>
+                <th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job Name</th>
                 <th data-field="job_status.name" data-sortable="true">Status</th>
                 <th data-field="customer.last_name" data-sortable="true">Last Name</th>
                 <th data-field="customer.first_name" data-sortable="true">First Name</th>
@@ -282,31 +282,22 @@
     </div>
   </div>
 
-    <script>
-$("#menu-toggle").click(function (e) {
-    e.preventDefault();
-    $("#wrapper").toggleClass("toggled");
+  <script>
+    $("#menu-toggle").click(function (e) {
+      e.preventDefault();
+      $("#wrapper").toggleClass("toggled");
     });
-function LinkFormatter(value, row, index) {
-  return "<a target='_blank href='/calls/" + row.id + ">" + value + "</a>";
-}
-function AddVendor(value, row, index) {
-  return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
-}
-function CallRailTimeline(value, row, index) {
-  return "<a href='https://app.callrail.com/calls/" + value + "'>Timeline Link</a>";
-}
 
-flatpickr(".datePicker", {
-enableTime: false,
-// create an extra input solely for display purposes
-altInput: true,
-altFormat: "F j, Y"
-});
+    flatpickr(".datePicker", {
+      enableTime: false,
+      // create an extra input solely for display purposes
+      altInput: true,
+      altFormat: "F j, Y"
+    });
 
-$('[data-toggle=tab]').click(function () {
-    if ($(this).parent().hasClass('active')) {
-    $($(this).attr("href")).toggleClass('active');
-    }
+    $('[data-toggle=tab]').click(function () {
+      if ($(this).parent().hasClass('active')) {
+      $($(this).attr("href")).toggleClass('active');
+      }
     })
-    </script>
+  </script>

--- a/app/views/home/admin.html.erb
+++ b/app/views/home/admin.html.erb
@@ -1,17 +1,3 @@
-<!-- <div class="col-sm-12 col-lg-12 main">
-	<div class="row">
-		<ol class="breadcrumb">
-			<li>
-				<a href="#">
-					<svg class="glyph stroked home">
-						<use xlink:href="#stroked-home"></use>
-					</svg>
-				</a>
-			</li>
-			<li class="active">Dashboard</li>
-		</ol>
-	</div> -->
-<!--/.row-->
 <div class="container-fluid">
 
 	<section id="home">
@@ -83,25 +69,6 @@
 				<div class="panel panel-default">
 					<div class="panel-heading">Jobs</div>
 					<div class="panel-body">
-						<!-- <table id="table"
-				           data-toolbar="#toolbar"
-				           data-search="true"
-				           data-show-refresh="true"
-				           data-show-toggle="true"
-				           data-show-columns="true"
-				           data-show-export="true"
-				           data-detail-view="true"
-				           data-detail-formatter="detailFormatter"
-				           data-minimum-count-columns="2"
-				           data-show-pagination-switch="true"
-				           data-pagination="true"
-				           data-id-field="id"
-				           data-page-list="[10, 25, 50, 100, ALL]"
-				           data-show-footer="false"
-				           data-side-pagination="server"
-				           data-url="/examples/bootstrap_table/data"
-				           data-response-handler="responseHandler">
-				    </table> -->
 						<table
 							class="table-responsive"
 							data-toggle="table"
@@ -117,7 +84,7 @@
 							data-sort-order="desc">
 							<thead>
 								<tr>
-									<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job Name</th>
+									<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job Name</th>
 									<th data-field="job_status.name" data-sortable="true">Status</th>
 									<th data-field="customer.last_name" data-sortable="true">Last Name</th>
 									<th data-field="customer.first_name" data-sortable="true">First Name</th>
@@ -210,7 +177,7 @@
 							data-sort-order="desc">
 							<thead>
 								<tr>
-									<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job Name</th>
+									<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job Name</th>
 									<th data-field="job_status.name" data-sortable="true">Status</th>
 									<th data-field="customer.last_name" data-sortable="true">Last Name</th>
 									<th data-field="customer.first_name" data-sortable="true">First Name</th>
@@ -273,7 +240,7 @@
 							data-sort-order="desc">
 							<thead>
 								<tr>
-									<th data-field="id" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job ID</th>
+									<th data-field="id" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job ID</th>
 									<th data-field="job_status.name" data-sortable="true">Status</th>
 									<th data-field="customer.last_name" data-sortable="true">Last Name</th>
 									<th data-field="customer.first_name" data-sortable="true">First Name</th>
@@ -307,7 +274,7 @@
 							data-sort-order="desc">
 							<thead>
 								<tr>
-									<th data-field="id" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job ID</th>
+									<th data-field="id" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job ID</th>
 									<th data-field="job_status.name" data-sortable="true">Status</th>
 									<th data-field="customer.last_name" data-sortable="true">Last Name</th>
 									<th data-field="customer.first_name" data-sortable="true">First Name</th>

--- a/app/views/home/call_rep.html.erb
+++ b/app/views/home/call_rep.html.erb
@@ -1,17 +1,3 @@
-<!-- <div class="col-sm-12 col-lg-12 main">
-	<div class="row">
-		<ol class="breadcrumb">
-			<li>
-				<a href="#">
-					<svg class="glyph stroked home">
-						<use xlink:href="#stroked-home"></use>
-					</svg>
-				</a>
-			</li>
-			<li class="active">Dashboard</li>
-		</ol>
-	</div> -->
-<!--/.row-->
 <section id="home">
 
 	<div class="row">

--- a/app/views/home/collections.html.erb
+++ b/app/views/home/collections.html.erb
@@ -1,20 +1,4 @@
-<!-- <div class="col-sm-12 col-lg-12 main">
-	<div class="row">
-		<ol class="breadcrumb">
-			<li>
-				<a href="#">
-					<svg class="glyph stroked home">
-						<use xlink:href="#stroked-home"></use>
-					</svg>
-				</a>
-			</li>
-			<li class="active">Dashboard</li>
-		</ol>
-	</div> -->
-<!--/.row-->
 <div class="container-fluid">
-
-
 <section id="home">
 
 	<div class="row">
@@ -42,7 +26,7 @@
 						data-sort-order="desc">
 						<thead>
 							<tr>
-								<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job Name</th>
+								<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job Name</th>
 								<th data-field="job_status.name" data-sortable="true">Status</th>
 								<th data-field="customer.last_name" data-sortable="true">Last Name</th>
 								<th data-field="customer.first_name" data-sortable="true">First Name</th>
@@ -76,7 +60,7 @@
 						data-sort-order="desc">
 						<thead>
 							<tr>
-								<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job Name</th>
+								<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job Name</th>
 								<th data-field="job_status.name" data-sortable="true">Status</th>
 								<th data-field="customer.last_name" data-sortable="true">Last Name</th>
 								<th data-field="customer.first_name" data-sortable="true">First Name</th>

--- a/app/views/home/contractor.html.erb
+++ b/app/views/home/contractor.html.erb
@@ -1,20 +1,4 @@
-<!-- <div class="col-sm-12 col-lg-12 main">
-	<div class="row">
-		<ol class="breadcrumb">
-			<li>
-				<a href="#">
-					<svg class="glyph stroked home">
-						<use xlink:href="#stroked-home"></use>
-					</svg>
-				</a>
-			</li>
-			<li class="active">Dashboard</li>
-		</ol>
-	</div> -->
-<!--/.row-->
 <div class="container-fluid">
-
-
 <section id="home">
 
 	<div class="row">

--- a/app/views/home/crew_chief.html.erb
+++ b/app/views/home/crew_chief.html.erb
@@ -1,17 +1,3 @@
-<!-- <div class="col-sm-12 col-lg-12 main">
-	<div class="row">
-		<ol class="breadcrumb">
-			<li>
-				<a href="#">
-					<svg class="glyph stroked home">
-						<use xlink:href="#stroked-home"></use>
-					</svg>
-				</a>
-			</li>
-			<li class="active">Dashboard</li>
-		</ol>
-	</div> -->
-<!--/.row-->
 <div class="container-fluid">
 
 	<section id="home">

--- a/app/views/home/job_coordinator.html.erb
+++ b/app/views/home/job_coordinator.html.erb
@@ -1,20 +1,4 @@
-<!-- <div class="col-sm-12 col-lg-12 main">
-	<div class="row">
-		<ol class="breadcrumb">
-			<li>
-				<a href="#">
-					<svg class="glyph stroked home">
-						<use xlink:href="#stroked-home"></use>
-					</svg>
-				</a>
-			</li>
-			<li class="active">Dashboard</li>
-		</ol>
-	</div> -->
-<!--/.row-->
 <div class="container-fluid">
-
-
 <section id="home">
 
 	<div class="row">
@@ -220,7 +204,7 @@
 						data-sort-order="desc">
 						<thead>
 							<tr>
-								<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job Name</th>
+								<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job Name</th>
 								<th data-field="job_status.name" data-sortable="true">Status</th>
 								<th data-field="customer.last_name" data-sortable="true">Last Name</th>
 								<th data-field="customer.first_name" data-sortable="true">First Name</th>
@@ -254,7 +238,7 @@
 						data-sort-order="desc">
 						<thead>
 							<tr>
-								<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="LinkFormatter">Job Name</th>
+								<th data-field="name" data-sort-order='desc' data-sortable="true" data-formatter="JobLinkFormatter">Job Name</th>
 								<th data-field="job_status.name" data-sortable="true">Status</th>
 								<th data-field="customer.last_name" data-sortable="true">Last Name</th>
 								<th data-field="customer.first_name" data-sortable="true">First Name</th>

--- a/app/views/home/technician.html.erb
+++ b/app/views/home/technician.html.erb
@@ -1,17 +1,3 @@
-<!-- <div class="col-sm-12 col-lg-12 main">
-	<div class="row">
-		<ol class="breadcrumb">
-			<li>
-				<a href="#">
-					<svg class="glyph stroked home">
-						<use xlink:href="#stroked-home"></use>
-					</svg>
-				</a>
-			</li>
-			<li class="active">Dashboard</li>
-		</ol>
-	</div> -->
-<!--/.row-->
 <div class="container-fluid">
 
 	<section id="home">

--- a/app/views/insurance_companies/index.html.erb
+++ b/app/views/insurance_companies/index.html.erb
@@ -23,7 +23,7 @@
                         <thead>
                             <tr>
                                 <th data-field="state" data-checkbox="true">Insurance Company ID</th>
-                                <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Insurance Company ID</th>
+                                <th data-field="id" data-sortable="true" data-formatter="InsuranceCompanyLinkFormatter">Insurance Company ID</th>
                                 <th data-field="name" data-sortable="true">Name</th>
                                 <th data-field="bulletin_number" data-sortable="true">Bulletin Number</th>
                                 <th data-field="effective_date" data-sortable="true">Effective Date</th>
@@ -44,10 +44,3 @@
         </div>
     </div>
 </div>
-
-
-<script>
-    function LinkFormatter(value, row, index) {
-        return "<a href='insurance_companies/" + row.id + "'>" + value + "</a>";
-    }
-</script>

--- a/app/views/insurance_companies/show.html.erb
+++ b/app/views/insurance_companies/show.html.erb
@@ -194,15 +194,6 @@
             e.preventDefault();
             $("#wrapper").toggleClass("toggled");
         });
-        function LinkFormatter(value, row, index) {
-            return "<a target='_blank href='/calls/" + row.id + ">" + value + "</a>";
-        }
-        function AddVendor(value, row, index) {
-            return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
-        }
-        function CallRailTimeline(value, row, index) {
-            return "<a href='https://app.callrail.com/calls/" + value + "'>Timeline Link</a>";
-        }
 
         flatpickr(".datePicker", {
             enableTime: false,

--- a/app/views/jobs/add_call.html.erb
+++ b/app/views/jobs/add_call.html.erb
@@ -51,7 +51,7 @@
                                 <thead>
                                     <tr>
                                         <th data-field="id" data-sortable="true" data-formatter="AddVendor"></th>
-                                        <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Call Link</th>
+                                        <th data-field="id" data-sortable="true" data-formatter="CallLinkFormatter">Call Link</th>
                                         <th data-field="callrail_id" data-sortable="true">CallRail ID</th>
                                         <th data-field="datetime" data-sortable="true">Call Date/Time</th>
                                         <th data-field="customer_phone_number" data-sortable="true">Phone Number</th>
@@ -71,15 +71,3 @@
 
 </div>
 </div>
-
-<script>
-function LinkFormatter(value, row, index) {
-    return "<a target='_blank href='/calls/" + row.id + ">" + value + "</a>";
-}
-function AddVendor(value, row, index) {
-    return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
-}
-function CallRailTimeline(value, row, index) {
-    return "<a href='https://app.callrail.com/calls/" + value + "'>Timeline Link</a>";
-}
-</script>

--- a/app/views/jobs/search.html.erb
+++ b/app/views/jobs/search.html.erb
@@ -18,7 +18,7 @@
 					data-sort-order="desc">
 					<thead>
 						<tr>
-							<th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Job ID</th>
+							<th data-field="id" data-sortable="true" data-formatter="JobLinkFormatter">Job ID</th>
 							<th data-field="job_status.name" data-sortable="false">Status</th>
 							<th data-field="customer.last_name" data-sortable="false">Last Name</th>
 							<th data-field="customer.first_name" data-sortable="false">First Name</th>
@@ -34,9 +34,3 @@
 		</div>
 	</div>
 </div>
-
-<script>
-	function LinkFormatter(value, row, index) {
-		return "<a href='" + row.id + "'>" + value + "</a>";
-	}
-</script>

--- a/app/views/jobs/show.html.erb
+++ b/app/views/jobs/show.html.erb
@@ -353,7 +353,7 @@
                                                     <thead>
                                                         <tr>
                                                           <th data-field="callrail_id" data-sortable="true" data-formatter="ReturnCallRail">CallRail Timeline</th>
-                                                            <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Call Link</th>
+                                                            <th data-field="id" data-sortable="true" data-formatter="CallLinkFormatter">Call Link</th>
                                                             <th data-field="callrail_id" data-sortable="true">CallRail ID</th>
                                                             <th data-field="datetime" data-sortable="true">Call Date/Time</th>
                                                             <th data-field="customer_phone_number" data-sortable="true">Phone Number</th>
@@ -387,7 +387,7 @@
                                                     <thead>
                                                         <tr>
                                                             <th data-field="id" data-sortable="true" data-formatter="AddVendor"></th>
-                                                            <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Call Link</th>
+                                                            <th data-field="id" data-sortable="true" data-formatter="CallLinkFormatter">Call Link</th>
                                                             <th data-field="callrail_id" data-sortable="true">CallRail ID</th>
                                                             <th data-field="datetime" data-sortable="true">Call Date/Time</th>
                                                             <th data-field="customer_phone_number" data-sortable="true">Phone Number</th>
@@ -910,18 +910,6 @@
             e.preventDefault();
             $("#wrapper").toggleClass("toggled");
         });
-        function LinkFormatter(value, row, index) {
-            return "<a target='_blank href='/calls/" + row.id + ">" + value + "</a>";
-        }
-        function AddVendor(value, row, index) {
-            return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
-        }
-        function CallRailTimeline(value, row, index) {
-            return "<a href='https://app.callrail.com/calls/" + value + "'>Timeline Link</a>";
-        }
-        function ReturnCallRail(value, row, index){
-            return "<a class='btn btn-primary' href='https://app.callrail.com/a/686639065/leadcenter/#/calls/" + value + "'>Return Call</a>";
-        }
 
         flatpickr(".datePicker", {
             enableTime: false,

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -29,7 +29,7 @@
                 <th data-field="upload_category.name" data-sortable="true">Upload Cateogry</th>
                 <th data-field="id" data-sortable="true">Upload ID</th>
                 <th data-field="file_name" data-sortable="true">Name</th>
-                <th data-field="upload.url" data-formatter="LinkFormatter" data-sortable="true">Link</th>
+                <th data-field="upload.url" data-formatter="UploadLinkFormatter" data-sortable="true">Link</th>
                 <th data-field="id" data-formatter="DeleteUpload" data-sortable="true">Delete</th>
 
               </tr>
@@ -41,13 +41,3 @@
     </div>
   </div>
 </div>
-<script>
-    function LinkFormatter(value, row, index) {
-
-        return "<a href=" + value + ">View/Download</a>";
-    }
-
-    function DeleteUpload(value, row, index) {
-        return "<a data-method='delete' data-confirm='Are you sure?' href='/jobs/<%= @job.id %>/uploads/" + row.id + "'>Delete</a>";
-    }
-</script>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -104,15 +104,6 @@
       e.preventDefault();
       $("#wrapper").toggleClass("toggled");
     });
-    function LinkFormatter(value, row, index) {
-      return "<a target='_blank href='/calls/" + row.id + ">" + value + "</a>";
-    }
-    function AddVendor(value, row, index) {
-      return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
-    }
-    function CallRailTimeline(value, row, index) {
-      return "<a href='https://app.callrail.com/calls/" + value + "'>Timeline Link</a>";
-    }
 
     flatpickr(".datePicker", {
       enableTime: false,

--- a/app/views/vendor_assignments/_form.html.erb
+++ b/app/views/vendor_assignments/_form.html.erb
@@ -66,7 +66,7 @@
             <thead>
                 <tr>
                     <th data-field="id" data-sortable="true" data-formatter="AddVendor"></th>
-                    <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Vendor ID</th>
+                    <th data-field="id" data-sortable="true" data-formatter="VendorLinkFormatter">Vendor ID</th>
                     <th data-field="name" data-sortable="true">Name</th>
                     <th data-field="category_type" data-sortable="true">Category Type</th>
                     <th data-field="contact" data-sortable="true">Contact</th>
@@ -90,9 +90,6 @@
 
 
 <script>
-    function LinkFormatter(value, row, index) {
-        return "<a href='/vendors/" + row.id + "'>" + value + "</a>";
-    }
     function AddVendor(value, row, index) {
         return "<a class='add-vendor' href='id=" + row.id + "&name=" + row.name + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
     }

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -26,7 +26,7 @@
                         <thead>
                             <tr>
                                 <th data-field="state" data-checkbox="true">Vendor ID</th>
-                                <th data-field="id" data-sortable="true" data-formatter="LinkFormatter">Vendor ID</th>
+                                <th data-field="id" data-sortable="true" data-formatter="VendorLinkFormatter">Vendor ID</th>
                                 <th data-field="name" data-sortable="true">Name</th>
                                 <th data-field="category_type" data-sortable="true">Category Type</th>
                                 <th data-field="contact" data-sortable="true">Contact</th>

--- a/app/views/vendors/show.html.erb
+++ b/app/views/vendors/show.html.erb
@@ -290,9 +290,6 @@
       e.preventDefault();
       $("#wrapper").toggleClass("toggled");
     });
-    function LinkFormatter(value, row, index) {
-      return "<a target='_blank href='/calls/" + row.id + ">" + value + "</a>";
-    }
     function AddVendor(value, row, index) {
       return "<a class='add-call' target='_blank' href='call_id=" + row.id + "'><span class='glyphicon glyphicon-plus' aria-hidden='true'></span></a>";
     }


### PR DESCRIPTION
They went to a job not a vendor.

This PR takes on a bit more than that, and moves all `LinkFormatter`s into the `bootstrap-table-formatters.js` file.