### PR TITLE
Add new work order link to list

### DIFF
--- a/app/views/work_orders/index.html.erb
+++ b/app/views/work_orders/index.html.erb
@@ -10,6 +10,11 @@
             <div class="alert alert-info">
               <%= link_to "Click here", @job %> to return to the job
             </div>
+            <div>
+              <%= link_to new_job_work_order_path(@job), class: 'btn btn-primary' do %>
+                <i class="fa fa-plus"></i> New Work Order
+              <% end %>
+            </div>
             <%= render partial: 'datatables/work_orders', locals: {
               filter: "job_id=#{@job.id}",
               columns: [


### PR DESCRIPTION
I missed this commit from the last PR so created a new PR for it.

As it goes, I changed the work_orders#index route to list work orders, so the link from a job should be a bit more sensible now